### PR TITLE
fix: update bucket name in terraform.tfvars

### DIFF
--- a/tf/terraform.tfvars
+++ b/tf/terraform.tfvars
@@ -11,7 +11,7 @@
 ## =====================================================================================================================
 
 
-bucket-name      = "subhamay-tf-template-bucket-06611-97"
+bucket-name      = "subhamay-tf-template-bucket-06611-98"
 project-name     = "gha-tmpl"
 environment-name = "devl"
 


### PR DESCRIPTION
This pull request includes a minor update to the `tf/terraform.tfvars` file, changing the `bucket-name` value to reflect a new bucket identifier.