### PR TITLE
fix: update permissions and run-name in workflow files

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -25,6 +25,7 @@ on:
 permissions:
   contents: write
   id-token: write
+  actions: read
 
 jobs:
 

--- a/.github/workflows/notify.yaml
+++ b/.github/workflows/notify.yaml
@@ -1,4 +1,5 @@
 name: Trigger Slack Notification
+run-name: Trigger Slack Notification run by ${{ github.actor }} on ${{ github.ref_name }}
 
 on:
   pull_request:


### PR DESCRIPTION
This pull request introduces minor updates to GitHub Actions workflow files to enhance functionality and clarity.

GitHub Actions workflow updates:

* [`.github/workflows/create-release.yaml`](diffhunk://#diff-a318819fb0ec8889018cbef8e6dd222e317757d95ddd93b62b714ac7c49f04f6R28): Added `actions: read` permission to the `permissions` section to ensure proper access for actions during the workflow execution.
* [`.github/workflows/notify.yaml`](diffhunk://#diff-0585fd55e01de551597c159b1b06185f08602999ee2aea9097bff136ceb70fe7R2): Added a `run-name` field to dynamically display the actor and branch name in the Slack notification workflow for better traceability.