### PR TITLE
fix: update bucket name in terraform.tfvars

### DIFF
--- a/tf/terraform.tfvars
+++ b/tf/terraform.tfvars
@@ -11,7 +11,7 @@
 ## =====================================================================================================================
 
 
-bucket-name      = "subhamay-tf-template-bucket-06611-142"
+bucket-name      = "subhamay-tf-template-bucket-06611-143"
 project-name     = "gha-tmpl"
 environment-name = "devl"
 


### PR DESCRIPTION
This pull request includes a small change to the `tf/terraform.tfvars` file. The change updates the `bucket-name` variable to reflect a new bucket identifier.